### PR TITLE
Set command services as public

### DIFF
--- a/DependencyInjection/Compiler/BunnyCompilerPass.php
+++ b/DependencyInjection/Compiler/BunnyCompilerPass.php
@@ -181,21 +181,27 @@ class BunnyCompilerPass implements CompilerPassInterface
 		$channelDefinition->setPublic(true);
 		$container->setDefinition($this->channelServiceId, $channelDefinition);
 
-		$container->setDefinition($this->setupCommandServiceId, new Definition("Skrz\\Bundle\\BunnyBundle\\Command\\SetupCommand", [
+		$setupCommandDefinition = new Definition("Skrz\\Bundle\\BunnyBundle\\Command\\SetupCommand", [
 			new Reference($this->managerServiceId),
-		]));
+		]);
+		$setupCommandDefinition->setPublic(true);
+		$container->setDefinition($this->setupCommandServiceId, $setupCommandDefinition);
 
-		$container->setDefinition($this->consumerCommandServiceId, new Definition("Skrz\\Bundle\\BunnyBundle\\Command\\ConsumerCommand", [
+		$consumerCommandDefinition = new Definition("Skrz\\Bundle\\BunnyBundle\\Command\\ConsumerCommand", [
 			new Reference("service_container"),
 			new Reference($this->managerServiceId),
 			$consumers,
-		]));
+		]);
+		$consumerCommandDefinition->setPublic(true);
+		$container->setDefinition($this->consumerCommandServiceId, $consumerCommandDefinition);
 
-		$container->setDefinition($this->producerCommandServiceId, new Definition("Skrz\\Bundle\\BunnyBundle\\Command\\ProducerCommand", [
+		$producerCommandDefinition = new Definition("Skrz\\Bundle\\BunnyBundle\\Command\\ProducerCommand", [
 			new Reference("service_container"),
 			new Reference($this->managerServiceId),
 			$producers,
-		]));
+		]);
+		$producerCommandDefinition->setPublic(true);
+		$container->setDefinition($this->producerCommandServiceId, $producerCommandDefinition);
 	}
 
 	private function getCandidateServices(ContainerBuilder $container, array $config)


### PR DESCRIPTION
Solves error:
```
The "command.bunny.setup" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.
```

that is thrown because of
```
        public function registerCommands(Application $application)
	{
		/** @var Command[] $commands */
		$commands = [
			$this->container->get("command.bunny.setup"),
			$this->container->get("command.bunny.consumer"),
			$this->container->get("command.bunny.producer"),
		];

		foreach ($commands as $command) {
			$application->add($command);
		}
	}
```

in SkrzBunnyBundle.php